### PR TITLE
Fixes incorrect phpdoc param type on class_uses_trait

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -65,7 +65,7 @@ if (! function_exists('class_uses_trait')) {
     /**
      * Check whether or not a class uses a particular trait
      *
-     * @param  class $class
+     * @param  string|object $class
      * @param  string $trait
      * @return boolean
      */


### PR DESCRIPTION
Both `class_uses_recursive` and `class_uses` use `string|object` for the parameter type as `class` isn't valid.